### PR TITLE
Feature/updates

### DIFF
--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -257,6 +257,14 @@ class Event implements SluggableEntityInterface
         return $this->tags;
     }
 
+    // Used in a listener when tags are disabled
+    public function clearTags(): static
+    {
+        $this->tags = new ArrayCollection();
+
+        return $this;
+    }
+
     public function addTag(EventTag $tag): static
     {
         if (!$this->tags->contains($tag)) {

--- a/src/EventListener/EventListener.php
+++ b/src/EventListener/EventListener.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OHMedia\EventBundle\EventListener;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\Event\PostLoadEventArgs;
+use Doctrine\ORM\Events;
+use OHMedia\EventBundle\Entity\Event;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsEntityListener(event: Events::postLoad, method: 'postLoad', entity: Event::class)]
+class EventListener
+{
+    public function __construct(
+        #[Autowire('%oh_media_event.event_tags%')]
+        private bool $eventTagsEnabled,
+    ) {
+    }
+
+    public function postLoad(Event $event, PostLoadEventArgs $eventArgs)
+    {
+        if (!$this->eventTagsEnabled) {
+            $event->clearTags();
+        }
+    }
+}

--- a/src/Service/EventNavItemProvider.php
+++ b/src/Service/EventNavItemProvider.php
@@ -10,11 +10,32 @@ use OHMedia\EventBundle\Entity\Event;
 use OHMedia\EventBundle\Entity\EventTag;
 use OHMedia\EventBundle\Security\Voter\EventTagVoter;
 use OHMedia\EventBundle\Security\Voter\EventVoter;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class EventNavItemProvider extends AbstractNavItemProvider
 {
+    public function __construct(
+        private AuthorizationCheckerInterface $authorizationChecker,
+        #[Autowire('%oh_media_event.event_tags%')]
+        private bool $eventTagsEnabled,
+    ) {
+        parent::__construct($authorizationChecker);
+    }
+
     public function getNavItem(): ?NavItemInterface
     {
+        if (!$this->eventTagsEnabled) {
+            if ($this->isGranted(EventVoter::INDEX, new Event())) {
+                $events = new NavLink('Events', 'event_index');
+                $events->setIcon('calendar3');
+
+                return $events;
+            } else {
+                return null;
+            }
+        }
+
         $nav = (new NavDropdown('Events'))
             ->setIcon('calendar3');
 

--- a/templates/event/event_form.html.twig
+++ b/templates/event/event_form.html.twig
@@ -43,7 +43,9 @@
           {{ form_row(form.location) }}
           {{ form_row(form.ticket_url) }}
           {{ form_row(form.image) }}
-          {{ form_row(form.tags) }}
+          {% if form.tags is defined %}
+            {{ form_row(form.tags) }}
+          {% endif %}
           {{ form_row(form.timezone) }}
 
           {% do form.times.setRendered %}


### PR DESCRIPTION
Fixed an existing bug on the event form when tags are disabled.

Updated sidebar nav for Events to not be a dropdown if tags are disabled.

Ensured event.tags is cleared if tags are disabled.